### PR TITLE
Correct typos + on.exit for parallel

### DIFF
--- a/R/evaluate_models.R
+++ b/R/evaluate_models.R
@@ -413,7 +413,8 @@ evaluate_models <- function(input_data,
   } else {
     cl <- parallel::makeCluster(ncores)
     doParallel::registerDoParallel(cl)
-
+    on.exit(parallel::stopCluster(cl))
+    
     vc_res_gam <- foreach::foreach(
       i = 1:nrow(terms_grid),
       .combine = "rbind",
@@ -423,7 +424,6 @@ evaluate_models <- function(input_data,
                    vars, coords_x, coords_y, time_var, spatial_k, temporal_k)
     }
 
-    parallel::stopCluster(cl)
   }
 
   return(vc_res_gam)

--- a/vignettes/stgam_intro_chaco.Rmd
+++ b/vignettes/stgam_intro_chaco.Rmd
@@ -191,7 +191,7 @@ ggplot() +
   theme_bw()
 ```
 
-Thus, this diversion into smooths and splines illustrates how they model different relationships (slopes) with `y` at different locations within the variable feature space, (the `x` axis in the above example). In this way, spline smooth curves can be used to capture non-linear relationships in attribute-space (here the relationship of `x` with `y`).
+Thus, this diversion into smooths and splines illustrates how they model different relationships (slopes) with `y` at different locations within the variable feature space (the `x` axis in the above example). In this way, spline smooth curves can be used to capture non-linear relationships in attribute-space (here the relationship of `x` with `y`).
 
 Importantly, in the context of space-time varying coefficient modelling with `stgam` (see the accompanying vignette in this package), the smooth can be used to model how relationships between `x` and `y` varies with respect to time or location, if the smooth is also parameterised with those. That is moving from attribute-space to temporal- or geographical-space, respectively.
 

--- a/vignettes/stgam_vc_models_chaco.Rmd
+++ b/vignettes/stgam_vc_models_chaco.Rmd
@@ -590,7 +590,7 @@ t1 <- Sys.time()
 stvc_mods <- evaluate_models(
   input_data = chaco |> st_drop_geometry(),
   target_var = "ndvi", 
-  family = "gaussian()",
+  model_family = "gaussian()",
   vars = c("tmax", "pr"),
   coords_x = "X", 
   coords_y = "Y", 


### PR DESCRIPTION
Hi,

I removed a redundant comma in the vignette, renamed argument `family` to `model_family` of the `evaluate_models` in the vignette -as in the documentation - and used on.exit for safely closing the clusters in `evaluate_models`.

Thanks.